### PR TITLE
Update 2.1.0 beta 38

### DIFF
--- a/net.ankiweb.Anki.appdata.xml
+++ b/net.ankiweb.Anki.appdata.xml
@@ -20,8 +20,8 @@
   </screenshots>
   <translation>qt</translation>
   <releases>
+    <release version="2.1.0beta38" date="2018-05-01"/>
     <release version="2.1.0beta37" date="2018-03-01"/>
-    <release version="2.1.0beta36" date="2018-02-05"/>
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>

--- a/net.ankiweb.Anki.json
+++ b/net.ankiweb.Anki.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://apps.ankiweb.net/downloads/beta/anki-2.1.0beta37-source.tgz",
-          "sha256": "459e01d3bc132b0cb26d846e6d48b20eb416d55d7d19b569690b4f4961021860"
+          "url": "https://apps.ankiweb.net/downloads/beta/anki-2.1.0beta38-source.tgz",
+          "sha256": "a6d92f1ded1c501fd8b3f772426b03c715d933471a0b99a773eac2b49747679c"
         },
         {
           "type": "file",


### PR DESCRIPTION
Changes in beta 38

The experimental scheduler can now be enabled from the preferences screen, and warnings about data loss have been relaxed somewhat. It is still only recommended for advanced users at this point.

Also:

    Add the missing "custom steps" section back to the filtered deck options when using the regular scheduler.

    Fixes for dragging and pasting images from web browsers.

    Fix pastes with the middle mouse button on Linux.

    When switching to a different window and then back to the Anki editor, the cursor position is no longer moved to the bottom of the field.

    Fix a field getting overwritten when showing duplicates, and catch similar errors.

    Restore focus to Anki window after video finishes playing.

    Fix busy cursor in full sync screen.

    Add space to "waiting for editing" screen.

    Check uploads don’t exceed AnkiWeb limits.

    Added an option to disable certificate validation - see "SSL errors" above.

    Fix a "c++ object has been deleted" error message.

    For add-on authors, pycmd() can now return a value.

    Wording tweaks in find duplicates screen (thanks to homocomputeris)

    Ensure mpv doesn’t stay open (thanks to Dudemanguy911)

    Support non-Latin text in config.md (thanks to ljcooke)

    Fix the debug key shortcut on some keyboards (thanks to glutanimate)

    Tweaks to the makefile (thanks to dsd)