### PR TITLE
Update to Anki-bin v2.1.33 / KDE runtime v5.15

### DIFF
--- a/net.ankiweb.Anki.appdata.xml
+++ b/net.ankiweb.Anki.appdata.xml
@@ -28,6 +28,30 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2020-08-30" version="2.1.33">
+      <description>
+        <ul>
+          <li>Access More button in review screen with ‘m’ (thanks to ANH).</li>
+          <li>Audio no longer plays when dropped/pasted (thanks to ANH).</li>
+          <li>Fix bulk tag adding not adding tags if tag is a substring of an existing tag (thanks to Soren)</li>
+          <li>Fix cards not being unburied if leaving Anki open and the first action of a new day is a sync.</li>
+          <li>Fix drag&amp;drop into existing content (thanks to ANH).</li>
+          <li>Fix error when add-ons tried to access note/template in card template screen.</li>
+          <li>Fix next learn message in congrats screen.</li>
+          <li>Fix nonbreaking spaces in filenames not being handled properly.</li>
+          <li>Fix text in export file selector (thanks to ANH).</li>
+          <li>Fix timeouts in full syncs and media syncs again.</li>
+        </ul>
+      </description>
+    </release>
+    <release date="2020-08-25" version="2.1.32">
+      <description>
+        <ul>
+          <li>Roll back a change in the previous update that could cause syncs to time out.</li>
+          <li>Fix sign up link in login screen.</li>
+        </ul>
+      </description>
+    </release>
     <release date="2020-08-23" version="2.1.31">
       <description>
         <ul>

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -1,6 +1,6 @@
 app-id: net.ankiweb.Anki
 runtime: org.kde.Platform
-runtime-version: '5.14'
+runtime-version: '5.15'
 sdk: org.kde.Sdk
 command: anki
 rename-desktop-file: anki.desktop

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -59,8 +59,8 @@ modules:
       - /share/pixmaps
     sources:
       - type: archive
-        url: https://github.com/ankitects/anki/releases/download/2.1.31/anki-2.1.31-linux-amd64.tar.bz2
-        sha256: fe6a87e6fb309737bdd5a3dbfc3189c40b39809f534505eb5e90bbc3c4e0fa65 
+        url: https://github.com/ankitects/anki/releases/download/2.1.33/anki-2.1.33-linux-amd64.tar.bz2
+        sha256: f8963910649c3c8419ed6f5339b7e5abdeb9bf0651a1a0a22442119383f9d675
       - type: file
         path: anki.svg
       - type: file


### PR DESCRIPTION
Here you go!

Built the updated flatpak on my computer and it seems to open and work fine, but I didn't do any in-depth testing.