### PR TITLE
WIP: Enable Wayland support

### DIFF
--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -7,7 +7,8 @@ rename-desktop-file: anki.desktop
 rename-icon: anki
 finish-args:
   # X11/Wayland
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
   - --device=dri
   # Flashcards with sound


### PR DESCRIPTION
Anki/QT appears to support native Wayland just fine, so lets enable
it.

Also only allow X11 if Wayland is not available. This is a sandbox
feature for Wayland sessions.

Closes https://github.com/flathub/net.ankiweb.Anki/issues/45