### PR TITLE
Installing org.freedesktop.Sdk.Extension.texlive should be optional

### DIFF
--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -6,6 +6,7 @@ add-extensions:
   org.freedesktop.Sdk.Extension.texlive:
     version: '20.08'
     directory: texlive # this is relative to /app
+    no-autodownload: true
 command: anki
 rename-desktop-file: anki.desktop
 rename-icon: anki


### PR DESCRIPTION
Installing `org.freedesktop.Sdk.Extension.texlive` should be optional, especially since it's a large download and only needed for LaTeX support.