### PR TITLE
Update net.ankiweb.Anki.yaml

### DIFF
--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -13,6 +13,7 @@ rename-icon: anki
 finish-args:
   # X11/Wayland
   - --socket=x11
+  - --socket=wayland
   - --share=ipc
   - --device=dri
   # Flashcards with sound


### PR DESCRIPTION
added --socket=wayland flag.
Wayland works so why not include it in the config?