### PR TITLE
Change runtime to freedesktop and update dependencies

### DIFF
--- a/net.ankiweb.Anki.appdata.xml
+++ b/net.ankiweb.Anki.appdata.xml
@@ -8,7 +8,7 @@
   <description>
     <p>Anki is a program which makes remembering things easy. Because it's a lot more efficient than traditional study methods, you can either greatly decrease your time spent studying, or greatly increase the amount you learn.</p>
     <p>Anyone who needs to remember things in their daily life can benefit from Anki. Since it is content-agnostic and supports images, audio, videos and scientific markup (via LaTeX), the possibilities are endless.</p>
-    <p>Optional LaTeX support is provided by the TeX Live Flatpak extension org.freedesktop.Sdk.Extension.texlive//20.08.</p>
+    <p>Optional LaTeX support is provided by the TeX Live Flatpak extension org.freedesktop.Sdk.Extension.texlive//21.08.</p>
   </description>
   <kudos>
     <kudo>ModernToolkit</kudo>

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -56,11 +56,11 @@ modules:
       - python3 waf install
     sources:
       - type: archive
-        url: https://github.com/mpv-player/mpv/archive/v0.34.0.tar.gz
-        sha256: f654fb6275e5178f57e055d20918d7d34e19949bc98ebbf4a7371902e88ce309
+        url: https://github.com/mpv-player/mpv/archive/v0.34.1.tar.gz
+        sha256: 32ded8c13b6398310fa27767378193dc1db6d78b006b70dbcbd3123a1445e746
       - type: file
-        url: https://waf.io/waf-2.0.22
-        sha256: 0a09ad26a2cfc69fa26ab871cb558165b60374b5a653ff556a0c6aca63a00df1
+        url: https://waf.io/waf-2.0.23
+        sha256: 28a2e4583314a162cfcbffefb8a9202c1d7869040d30b5852da479b76d9c0491
         dest-filename: waf
     cleanup:
       - /include

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -1,10 +1,10 @@
 app-id: net.ankiweb.Anki
-runtime: org.kde.Platform
-runtime-version: '5.15'
-sdk: org.kde.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
 add-extensions:
   org.freedesktop.Sdk.Extension.texlive:
-    version: '20.08'
+    version: '21.08'
     directory: texlive # this is relative to /app
     no-autodownload: true
 command: anki


### PR DESCRIPTION
Changes the runtime to the latest version of org.freedesktop.Platform as suggested by #51.

Also updated mpv to 0.34.1 and waf to 2.0.23 while I was at it.