### PR TITLE
Change to the Qt6 build

### DIFF
--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -118,13 +118,13 @@ modules:
       - /share/pixmaps
     sources:
       - type: archive
-        url: https://github.com/ankitects/anki/releases/download/2.1.54/anki-2.1.54-linux-qt5.tar.zst
-        sha256: aa9cbfe5ed035ce73621b8d461d64bcde71621466f314c651e0af20676ff5c59
+        url: https://github.com/ankitects/anki/releases/download/2.1.54/anki-2.1.54-linux-qt6.tar.zst
+        sha256: 34586055de1cb44b21ee269267dbf438cb3377cd47e357aafb2f8544885c0ad1
         x-checker-data:
           type: json
           url: https://api.github.com/repos/ankitects/anki/releases/latest
           version-query: .tag_name
-          url-query: .assets[] | select(.name=="anki-" + $version + "-linux-qt5.tar.zst")
+          url-query: .assets[] | select(.name=="anki-" + $version + "-linux-qt6.tar.zst")
             | .browser_download_url
       - type: file
         path: anki.svg


### PR DESCRIPTION
This makes Anki use the Qt6 build instead of the Qt5 one it is using right now, which should close #71. Some further testing is necessary before it is merged, since there have been cases of add-ons not working when Qt6 is used.