### PR TITLE
Clean up .a files

### DIFF
--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -85,6 +85,7 @@ modules:
           - /include
           - /lib/cmake
           - /lib/pkgconfig
+          - /lib/*.a
         sources:
           - type: git
             url: https://github.com/google/shaderc.git


### PR DESCRIPTION
This brings the total installed size of the flatpak down from 1.4G to 486M.