### PR TITLE
(Need Testing) Add Discord (incl Clients) Rich Presence (RPC) support

### DIFF
--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -200,4 +200,3 @@ modules:
         test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
         done
         anki "$@"
-

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -196,7 +196,9 @@ modules:
       - type: script
         dest-filename: anki
         Commands:
-        for i in {0..9}; do
-        test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
-        done
-        anki "$@"
+          - |
+            for i in {0..9}; do
+              test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||
+                ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+            done
+            anki "$@"

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -195,7 +195,7 @@ modules:
           - sed -i 's/PREFIX=\/usr\/local/PREFIX=\/app/' install.sh
       - type: script
         dest-filename: anki
-        Commands:
+        commands:
           - |
             for i in {0..9}; do
               test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -27,7 +27,6 @@ finish-args:
   # LaTeX
   - --env=PATH=/app/bin:/usr/bin:/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux
   # Discord RPC Support
-  --filesystem=xdg-run/discord-ipc-*
   --filesystem=xdg-run/app/com.discordapp.Discord:create
   --filesystem=xdg-run/.flatpak/dev.vencord.Vesktop:create
   --filesystem=xdg-run/.flatpak/com.xyz.armcord.ArmCord:create

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -26,6 +26,11 @@ finish-args:
   - --env=IBUS_USE_PORTAL=1
   # LaTeX
   - --env=PATH=/app/bin:/usr/bin:/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux
+  # Discord RPC Support
+  --filesystem=xdg-run/discord-ipc-*
+  --filesystem=xdg-run/app/com.discordapp.Discord:create
+  --filesystem=xdg-run/.flatpak/dev.vencord.Vesktop:create
+  --filesystem=xdg-run/.flatpak/com.xyz.armcord.ArmCord:create
 
 modules:
   - name: texlive
@@ -188,3 +193,11 @@ modules:
         commands:
           - sed -i '/xdg-mime/d' install.sh
           - sed -i 's/PREFIX=\/usr\/local/PREFIX=\/app/' install.sh
+      - type: script
+        dest-filename: anki
+        Commands:
+        for i in {0..9}; do
+        test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+        done
+        anki "$@"
+

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -27,9 +27,10 @@ finish-args:
   # LaTeX
   - --env=PATH=/app/bin:/usr/bin:/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux
   # Discord RPC Support
-  --filesystem=xdg-run/app/com.discordapp.Discord:create
-  --filesystem=xdg-run/.flatpak/dev.vencord.Vesktop:create
-  --filesystem=xdg-run/.flatpak/com.xyz.armcord.ArmCord:create
+  - --filesystem=xdg-run/discord-ipc-*
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/.flatpak/dev.vencord.Vesktop:create
+  - --filesystem=xdg-run/.flatpak/com.xyz.armcord.ArmCord:create
 
 modules:
   - name: texlive


### PR DESCRIPTION
Trying to connect Discord Flatpak with Anki using this [Wiki about enabling RPC in flatpak apps](https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)#flatpak-applications) and the example from Flathub [docs](https://docs.flatpak.org/en/latest/electron.html#launching-the-app)

Then followed the implementation from [Dolphin Emulator](https://github.com/flathub/org.DolphinEmu.dolphin-emu/blob/b3f080f843a75b982782a8ddc28ee27ee93b07e0/org.DolphinEmu.dolphin-emu.yml#L108)

**But Dolphins adds `dolphin-emu "$@"` which replaced with anki, is this part necessary?**
```
for i in {0..9}; do
    test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
done
anki "$@"
```


`- --filesystem=xdg-run/discord-ipc-*`
This part of the code came from [Vesktop/Vencord](https://github.com/flathub/dev.vencord.Vesktop#flatpak-applications) and [ArmCord docs](https://github.com/flathub/xyz.armcord.ArmCord#flatpak-applications)

Would like users to test, because I couldn't due to lack of aarch build (and knowledge)

1. Install `flatpak install --user https://dl.flathub.org/build-repo/76118/net.ankiweb.Anki.flatpakref`
2. Install [Ankicord - Discord Rich Presence](https://ankiweb.net/shared/info/1828536813)
3. Enable [RPC](https://support.discord.com/hc/en-us/articles/7931156448919-Activity-Status-Rich-Presence-Settings)
4. In case it is not working -> Restart Discord and PC due to [false-alarms](https://github.com/STadas/Ankicord/issues?q=label%3Afalse-alarm+sort%3Aupdated-desc+is%3Aclosed)