### PR TITLE
Update Anki to 24.04 and ignore SPIRV-Tools 2024.1

### DIFF
--- a/net.ankiweb.Anki.appdata.xml
+++ b/net.ankiweb.Anki.appdata.xml
@@ -29,7 +29,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="23.12.1" date="2023-12-28">
+    <release version="24.04" date="2024-04-01">
       <description>
         <ul>
           <li>Anki official changelog: changes.ankiweb.net</li>

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -102,7 +102,7 @@ modules:
             x-checker-data:
               type: git
               tag-pattern: ^v(\d{4}\.\d{1})$
-              version:
+              versions:
                 !=: v2024.1
           - type: git
             url: https://github.com/KhronosGroup/SPIRV-Headers.git

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -65,8 +65,8 @@ modules:
         url: https://code.videolan.org/videolan/libplacebo.git
         mirror-urls:
           - https://github.com/haasn/libplacebo.git
-        tag: v6.338.1
-        commit: 2805a0d01c029084ab36bf5d0e3c8742012a0b27
+        tag: v6.338.2
+        commit: 64c1954570f1cd57f8570a57e51fb0249b57bb90
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
@@ -89,8 +89,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/google/shaderc.git
-            tag: v2023.8
-            commit: e6edd6d48fa5bdd9d176794c6810fae7f8e938e1
+            tag: v2024.0
+            commit: d792558a8902cb39b1c237243cc4edab226513a5
             x-checker-data:
               type: git
               tag-pattern: ^v(\d{4}\.\d{1,2})$
@@ -172,8 +172,8 @@ modules:
       - /share/pixmaps
     sources:
       - type: archive
-        url: https://github.com/ankitects/anki/releases/download/23.12.1/anki-23.12.1-linux-qt6.tar.zst
-        sha256: 6c5b4052a4a8152f025844a27a9597cb09dd9228c04db5a9e8225daa541e72e9
+        url: https://github.com/ankitects/anki/releases/download/24.04/anki-24.04-linux-qt6.tar.zst
+        sha256: 988438e3c79c043acca37aaca5754e04933fd0b79b27d940d49230cfbd14aa17
         x-checker-data:
           type: anitya
           is-main-source: true

--- a/net.ankiweb.Anki.yaml
+++ b/net.ankiweb.Anki.yaml
@@ -102,6 +102,8 @@ modules:
             x-checker-data:
               type: git
               tag-pattern: ^v(\d{4}\.\d{1})$
+              version:
+                !=: v2024.1
           - type: git
             url: https://github.com/KhronosGroup/SPIRV-Headers.git
             tag: sdk-1.3.250.1


### PR DESCRIPTION
SPIRV-Tools 2024.1 fails to build, so it gets ignored.